### PR TITLE
add SPDX-License-Identifier to source files

### DIFF
--- a/ini.h
+++ b/ini.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /*
  * libini - Library to read INI configuration files
  *

--- a/libini.c
+++ b/libini.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /*
  * libini - Library to read INI configuration files
  *


### PR DESCRIPTION
Adding an SPDX-License-Identifier to a C or header file is a best practice for clearly and unambiguously identifying the license of that source file.

This helps some scripts I'm writing for libiio, which checks licenses.