### PR TITLE
libini: harden parsing against malformed INI files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,14 @@ project(libini LANGUAGES C VERSION 0.1)
 
 include(GNUInstallDirs)
 
+if (NOT CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
+		"Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel."
+		FORCE
+	)
+	set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS None Debug Release RelWithDebInfo MinSizeRel)
+endif()
+
 set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
 	CACHE PATH "Installation directory for pkgconfig (.pc) files")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.10)
 project(libini LANGUAGES C VERSION 0.1)
 
 include(GNUInstallDirs)
@@ -33,6 +33,15 @@ set_target_properties(ini PROPERTIES
 )
 
 target_compile_definitions(ini PUBLIC ${INI_STATIC_CFLAGS})
+
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/example/test.c")
+    add_executable(libini_test example/test.c)
+    target_link_libraries(libini_test PRIVATE ini)
+    target_include_directories(libini_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    set_target_properties(libini_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+endif()
 
 install(TARGETS ini
 	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"

--- a/ini.h
+++ b/ini.h
@@ -74,7 +74,16 @@ __api int ini_read_pair(struct INI *ini,
 			const char **key, size_t *key_len,
 			const char **value, size_t *value_len);
 
-/* Set the read head to a specified offset. */
+/* Set the read head to a specified offset within the INI buffer.
+ *
+ * The pointer must point somewhere inside the buffer managed by this INI object.
+ * After calling this, ini_read_pair() or ini_next_section() will continue
+ * reading from the new position.
+ *
+ * WARNING: The library does not enforce any bounds or detect backward loops.
+ * It is the caller's responsibility to avoid moving the read pointer in a way
+ * that could cause infinite loops or repeated reads.
+ */
 __api void ini_set_read_pointer(struct INI *ini, const char *pointer);
 
 /* Get the number of the line that contains the specified address.

--- a/libini.c
+++ b/libini.c
@@ -94,8 +94,10 @@ struct INI *ini_open(const char *file)
 	}
 
 	ini = _ini_open_mem(buf, len - left, true);
-	if (!ini)
+	if (!ini) {
 		ret = -errno;
+		free(buf);
+	}
 
 error_fclose:
 	fclose(f);

--- a/libini.c
+++ b/libini.c
@@ -20,6 +20,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "ini.h"
 
@@ -121,6 +122,8 @@ err_set_errno:
 
 void ini_close(struct INI *ini)
 {
+	if (!ini)
+		return;
 	if (ini->free_buf_on_exit)
 		free((char *) ini->buf);
 	free(ini);
@@ -162,12 +165,22 @@ static bool skip_line(struct INI *ini)
 int ini_next_section(struct INI *ini, const char **name, size_t *name_len)
 {
 	const char *_name;
+	if (!ini)
+		return -EIO;
+
 	if (ini->curr == ini->end)
 		return 0; /* EOF: no more sections */
 
 	/* skip comments at start of file or current position */
 	if (ini->curr == ini->buf) {
-		if (skip_comments(ini) || *ini->curr != '[')
+		if (skip_comments(ini))
+			return -EIO;
+
+		// skip leading whitespace before the '[' char
+		while (ini->curr < ini->end && (*ini->curr == ' ' || *ini->curr == '\t'))
+			ini->curr++;
+
+		if (ini->curr == ini->end || *ini->curr != '[')
 			return -EIO;
 	} else while (ini->curr < ini->end && *ini->curr != '[' && !skip_line(ini));
 
@@ -175,11 +188,17 @@ int ini_next_section(struct INI *ini, const char **name, size_t *name_len)
 		return 0; /* EOF: no more sections */
 
 	/* move past the '[' */
-	_name = ++ini->curr;
+	ini->curr++;
+
+	// skip leading whitespace after the '[' char
+	while (ini->curr < ini->end && (*ini->curr == ' ' || *ini->curr == '\t'))
+		ini->curr++;
+
+	_name = ini->curr;
 	/* scan until closing ']' or end-of-line/end-of-buffer */
 	while (ini->curr < ini->end && *ini->curr != ']') {
-		if (*ini->curr == '\n') {
-			/* newline inside section name is invalid */
+		if (*ini->curr == '\n' || *ini->curr == '[') {
+			/* newline or '[' inside section name is invalid */
 			return -EIO;
 		}
 		ini->curr++;
@@ -194,11 +213,30 @@ int ini_next_section(struct INI *ini, const char **name, size_t *name_len)
 		/* defensive, should never happen */
 		if (tmp_len < 0)
 			return -EIO;
+		/* trim trailing whitespace */
+		while (tmp_len > 0 && (_name[tmp_len-1] == ' ' || _name[tmp_len-1] == '\t'))
+			tmp_len--;
+		/* empty name is bad */
+		if (!tmp_len)
+			return -EIO;
 		*name = _name;
 		*name_len = (size_t)tmp_len;
 	}
 
+	/* skip over the ']' char */
 	ini->curr++;
+	/* look at the rest of the line */
+	while (ini->curr < ini->end && *ini->curr != '\n') {
+		/* let skip_comments() handle it */
+		if (*ini->curr == '#')
+			break;
+		/* eat white space */
+		if (*ini->curr == ' ' || *ini->curr == '\t' || *ini->curr == '\r')
+			ini->curr++;
+		else
+			return -EIO;
+	}
+
 	return 1;
 }
 
@@ -207,13 +245,23 @@ int ini_read_pair(struct INI *ini,
 			const char **value, size_t *value_len)
 {
 	size_t _key_len = 0;
-	const char *_key, *_value, *curr, *end = ini->end;
+	const char *_key, *_value, *curr, *end;
 	ptrdiff_t tmp_len;
+
+	if (!ini)
+		return -EIO;
+	end = ini->end;
 
 	if (skip_comments(ini))
 		return 0;
+
+	/* skip whitespace at the start of the line */
+	while (ini->curr < ini->end && (*ini->curr == ' ' || *ini->curr == '\t'))
+		ini->curr++;
+
 	curr = _key = ini->curr;
 
+	/* section header, not a key/value pair */
 	if (*curr == '[')
 		return 0;
 
@@ -239,13 +287,14 @@ int ini_read_pair(struct INI *ini,
 		}
 	}
 
-	/* Skip whitespaces. */
+	/* Skip whitespaces after the '=' */
 	while (curr != end && (*curr == ' ' || *curr == '\t')) curr++;
 	if (curr == end)
 		return -EIO;
 
 	_value = curr;
 
+	/* find the end of the value */
 	while (curr != end && *curr != '\n') curr++;
 	if (curr == end)
 		return -EIO;
@@ -255,6 +304,11 @@ int ini_read_pair(struct INI *ini,
 	/* defensive, should never happen */
 	if (tmp_len < 0)
 		return -EIO;
+	/* trim trailing whitespace */
+	while (tmp_len > 0 &&
+			(_value[tmp_len - 1] == ' ' || _value[tmp_len - 1] == '\t'))
+		tmp_len--;
+
 	*value_len = (size_t)tmp_len;
 	*key = _key;
 	*key_len = _key_len;
@@ -265,6 +319,9 @@ int ini_read_pair(struct INI *ini,
 
 void ini_set_read_pointer(struct INI *ini, const char *pointer)
 {
+	if (!ini)
+		return;
+
 	if ((uintptr_t) pointer < (uintptr_t) ini->buf)
 		ini->curr = ini->buf;
 	else if ((uintptr_t) pointer > (uintptr_t) ini->end)
@@ -278,6 +335,8 @@ int ini_get_line_number(struct INI *ini, const char *pointer)
 	int line = 1;
 	const char *it;
 
+	if (!ini)
+		return -EIO;
 	if ((uintptr_t) pointer < (uintptr_t) ini->buf)
 		return -EINVAL;
 	if ((uintptr_t) pointer > (uintptr_t) ini->end)


### PR DESCRIPTION
PR Description
This PR improves libini robustness and safety, with a focus on making parsing more tolerant and not crashing on malformed input (fixes #3).

Section headers and key/value pairs now allow leading and trailing whitespace, enabling indented and more readable INI files without changing the public API. Parsing logic has been hardened based on Clang + libFuzzer findings to avoid invalid memory access and ambiguous states.

The PR also fixes a memory leak, removes unsafe alloca() usage in tests, adds defensive NULL checks and clearer API documentation, and modernizes the CMake configuration (default build type, minimum version, optional test target).